### PR TITLE
fix error 'invalid multibyte escape' in ruby 2.2. Force ASCII-8BIT en…

### DIFF
--- a/lib/parser/jpeg.rb
+++ b/lib/parser/jpeg.rb
@@ -14,8 +14,8 @@ class ImageSpec
       def self.detected?(stream)
         stream.rewind
         case stream.read(10)
-          when /^\xff\xd8\xff\xe0\x00\x10JFIF/ then true
-          when /^\xff\xd8\xff\xe1(.*){2}Exif/  then true
+          when /^\xff\xd8\xff\xe0\x00\x10JFIF/n then true
+          when /^\xff\xd8\xff\xe1(.*){2}Exif/n then true
           else false
         end
       end


### PR DESCRIPTION
when I updated my rails project from ruby 1.9.3 to ruby 2.2.2 I received the error message: 'invalid multibyte escape'.
